### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/config/secret_manager.py
+++ b/config/secret_manager.py
@@ -110,7 +110,7 @@ def validate_required_secrets():
 
     if missing:
         error_msg = f"Missing required secrets: {', '.join(missing)}"
-        logger.critical(error_msg)
+        logger.critical("One or more required secrets are missing. Please check the configuration.")
         raise RuntimeError(error_msg)
 
     return True


### PR DESCRIPTION
Potential fix for [https://github.com/brian0913579/linebot.test/security/code-scanning/5](https://github.com/brian0913579/linebot.test/security/code-scanning/5)

To fix the issue, we will modify the logging statement on line 113 to avoid including the names of the missing secrets in the log message. Instead, we will log a generic message indicating that required secrets are missing, without specifying their names. This ensures that no potentially sensitive information is exposed in the logs. The exception raised will still include the detailed error message, as it is intended for internal use and not for logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
