### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/config/secret_manager.py
+++ b/config/secret_manager.py
@@ -91,7 +91,7 @@ def get_secret(secret_name, default=None):
             return gcp_value
 
     # Return default if nothing found
-    logger.debug(f"Secret '{secret_name}' not found, using default value")
+    logger.debug("A secret was not found, using the default value")
     return default
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/brian0913579/linebot.test/security/code-scanning/4](https://github.com/brian0913579/linebot.test/security/code-scanning/4)

To fix the issue, we should avoid logging the `secret_name` directly. Instead, we can log a generic message that does not include the secret name. This ensures that no potentially sensitive information is exposed in the logs. The fix involves replacing the log message on line 94 with a more generic message that does not include the `secret_name`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
