### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/config/secret_manager.py
+++ b/config/secret_manager.py
@@ -64,7 +64,7 @@ def _get_secret_from_gcp(secret_name):
         response = client.access_secret_version(name=secret_path)
         return response.payload.data.decode("UTF-8")
     except Exception as e:
-        logger.error(f"Error retrieving secret '{secret_name}' from GCP: {str(e)}")
+        logger.error("Error retrieving a secret from GCP. Please check the configuration and permissions.")
         return None
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/brian0913579/linebot.test/security/code-scanning/3](https://github.com/brian0913579/linebot.test/security/code-scanning/3)

To fix the issue, we will remove the direct inclusion of `secret_name` in the log message. Instead, we will log a generic error message that does not reveal sensitive information. If additional context is needed for debugging, it can be provided in a secure manner, such as through secure debugging tools or by logging a sanitized version of the `secret_name`. 

The fix involves modifying the log message on line 67 to exclude `secret_name` and replacing it with a generic placeholder or omitting it entirely. This ensures that no sensitive information is exposed in the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
