### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brian0913579/linebot.test/security/code-scanning/1](https://github.com/brian0913579/linebot.test/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs linting and testing tasks, it does not require any write permissions. The `contents: read` permission is sufficient for these operations.

The `permissions` block will be added immediately after the `name` field in the workflow file. This ensures that the permissions apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
