### PR TITLE
Remove unnecessary permissions from OSSAR workflow

### DIFF
--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -12,9 +12,6 @@ on:
 
 permissions:
   contents:        read    # checkout code
-  id-token:        write  # allow OIDC token for msdo to Azure Defender
-  security-events: write   # publish SARIF
-  actions:         read    # required by upload-sarif in private repos
 
 jobs:
   ossar-scan:


### PR DESCRIPTION
Eliminate the `id-token` and `security-events` permissions from the OSSAR workflow to streamline access and enhance security.